### PR TITLE
Add Slack ticketing mode and Cloud Run deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+### Build stage
+FROM golang:1.23-alpine AS build
+
+WORKDIR /src
+
+RUN apk add --no-cache git
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/agent ./cmd/agent
+
+### Runtime stage
+# Uses the full golang:alpine image (not a scratch/alpine-only image) because
+# quality gates (RUN_VET_BEFORE_PR, RUN_TESTS_BEFORE_PR, self-healing) shell
+# out to `go vet`/`go test` against the *target* repo being modified.
+FROM golang:1.23-alpine
+
+RUN apk add --no-cache ca-certificates git
+
+WORKDIR /app
+COPY --from=build /out/agent /app/agent
+
+# Cloud Run injects PORT; default kept for local `docker run`.
+ENV PORT=8080
+EXPOSE 8080
+
+ENTRYPOINT ["/app/agent", "serve"]

--- a/cmd/agent/commands/helpers.go
+++ b/cmd/agent/commands/helpers.go
@@ -12,6 +12,7 @@ import (
 	"intern/internal/repository/github"
 	"intern/internal/ticketing"
 	jiraraw "intern/internal/ticketing/jira-raw"
+	slackticketing "intern/internal/ticketing/slack"
 
 	logger "github.com/jenish-jain/logger"
 )
@@ -19,7 +20,8 @@ import (
 // Dependencies holds all initialized dependencies for the application
 type Dependencies struct {
 	Config       *config.Config
-	JiraClient   interface{} // JIRA ticketing client
+	JiraClient   interface{}            // JIRA ticketing client
+	SlackClient  *slackticketing.Client // set only when TicketingMode == "slack"
 	TicketingSvc *ticketing.Service
 	GitHubClient repository.RepositoryClient
 	RepoSvc      *repository.RepositoryService
@@ -42,21 +44,37 @@ func InitDependencies(ctx context.Context) (*Dependencies, error) {
 		return nil, err
 	}
 
-	// Initialize JIRA client
-	jiraClient, err := jiraraw.NewRawClient(cfg.JiraURL, cfg.JiraEmail, cfg.JiraAPIToken)
-	if err != nil {
-		logger.Error("Failed to init JIRA client: %v", err)
-		return nil, err
-	}
+	// Initialize the ticketing backend based on TICKETING_MODE
+	var jiraClient interface{}
+	var slackClient *slackticketing.Client
+	var ticketingSvc *ticketing.Service
 
-	// Health check for JIRA
-	if err := jiraClient.HealthCheck(context.Background()); err != nil {
-		logger.Error("JIRA health check failed: %v", err)
-		return nil, err
+	switch cfg.TicketingMode {
+	case "slack":
+		client, err := slackticketing.NewSlackClient(cfg.SlackBotToken)
+		if err != nil {
+			logger.Error("Failed to init Slack client: %v", err)
+			return nil, err
+		}
+		if err := client.HealthCheck(context.Background()); err != nil {
+			logger.Error("Slack health check failed: %v", err)
+			return nil, err
+		}
+		slackClient = client
+		ticketingSvc = ticketing.NewService(client)
+	default: // "jira"
+		client, err := jiraraw.NewRawClient(cfg.JiraURL, cfg.JiraEmail, cfg.JiraAPIToken)
+		if err != nil {
+			logger.Error("Failed to init JIRA client: %v", err)
+			return nil, err
+		}
+		if err := client.HealthCheck(context.Background()); err != nil {
+			logger.Error("JIRA health check failed: %v", err)
+			return nil, err
+		}
+		jiraClient = client
+		ticketingSvc = ticketing.NewService(client)
 	}
-
-	// Create ticketing service
-	ticketingSvc := ticketing.NewService(jiraClient)
 
 	// Create repository path manager
 	workingDir := cfg.WorkingDir
@@ -102,6 +120,7 @@ func InitDependencies(ctx context.Context) (*Dependencies, error) {
 	return &Dependencies{
 		Config:       cfg,
 		JiraClient:   jiraClient,
+		SlackClient:  slackClient,
 		TicketingSvc: ticketingSvc,
 		GitHubClient: githubClient,
 		RepoSvc:      repoSvc,

--- a/cmd/agent/commands/init.go
+++ b/cmd/agent/commands/init.go
@@ -18,13 +18,23 @@ var InitCmd = &cobra.Command{
 func initConfig(cmd *cobra.Command, args []string) error {
 	logger.Info("Creating sample configuration files...")
 
-	envContent := `JIRA_URL="https://company.atlassian.net"
+	envContent := `# Ticketing Mode
+# Options: "jira" (default, polling loop) or "slack" (HTTP webhook, request-driven)
+TICKETING_MODE="jira"
+
+JIRA_URL="https://company.atlassian.net"
 JIRA_EMAIL="ai-agent@company.com"
 JIRA_API_TOKEN="your-jira-api-token"
 JIRA_PROJECT_KEY="PROJ"
 JIRA_TRANSITION_TO_DO="11"
 JIRA_TRANSITION_IN_PROGRESS="21"
 JIRA_TRANSITION_DONE="31"
+
+# Slack Configuration (required if TICKETING_MODE=slack)
+# See docs/SLACK_SETUP.md for how to create the app and get these values.
+# SLACK_BOT_TOKEN="xoxb-your-bot-token"
+# SLACK_SIGNING_SECRET="your-signing-secret"
+# PORT=8080  # HTTP port for the serve command; Cloud Run sets this automatically
 
 GITHUB_TOKEN="your-github-token"
 GITHUB_OWNER="company"

--- a/cmd/agent/commands/serve.go
+++ b/cmd/agent/commands/serve.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	slackticketing "intern/internal/ticketing/slack"
+
+	logger "github.com/jenish-jain/logger"
+	"github.com/spf13/cobra"
+)
+
+// ServeCmd starts the agent as an HTTP server: a request-driven entrypoint
+// (Slack webhook today) instead of the JIRA polling loop, and the mode
+// Cloud Run deploys — a container that scales to zero between requests.
+var ServeCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Serve the AI Intern Agent over HTTP (Slack webhook, request-driven)",
+	Long: `Start an HTTP server exposing the agent's request-driven trigger(s).
+Currently supports the Slack Events API webhook (requires TICKETING_MODE=slack).
+This is the entrypoint used for the Cloud Run deployment: it listens on $PORT,
+handles one ask per request, and scales to zero when idle.`,
+	RunE: serve,
+}
+
+func serve(cmd *cobra.Command, args []string) error {
+	logger.Info("Starting AI Intern Agent (serve mode)...")
+
+	deps, err := InitDependencies(context.Background())
+	if err != nil {
+		logger.Error("Failed to initialize dependencies: %v", err)
+		return err
+	}
+
+	if deps.Config.TicketingMode != "slack" {
+		return errors.New("agent serve requires TICKETING_MODE=slack (got " + deps.Config.TicketingMode + ")")
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.Handle("/slack/events", slackticketing.NewHandler(deps.SlackClient, deps.Config.SlackSigningSecret, deps.Coordinator))
+
+	addr := ":" + deps.Config.Port
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		logger.Info("Received shutdown signal, shutting down HTTP server...")
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer shutdownCancel()
+		_ = server.Shutdown(shutdownCtx)
+		cancel()
+	}()
+
+	logger.Info("Listening for Slack events", "addr", addr)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		logger.Error("HTTP server failed: %v", err)
+		return err
+	}
+
+	<-ctx.Done()
+	return nil
+}

--- a/cmd/agent/root.go
+++ b/cmd/agent/root.go
@@ -36,6 +36,7 @@ func init() {
 
 	// Add all subcommands
 	RootCmd.AddCommand(commands.StartCmd)
+	RootCmd.AddCommand(commands.ServeCmd)
 	RootCmd.AddCommand(commands.InitCmd)
 	RootCmd.AddCommand(commands.BuildIndexCmd)
 	RootCmd.AddCommand(commands.StatusCmd)

--- a/docs/CLOUD_RUN_DEPLOY.md
+++ b/docs/CLOUD_RUN_DEPLOY.md
@@ -1,0 +1,91 @@
+# Cloud Run Deployment
+
+Deploys the agent as a request-driven service: it scales to zero when idle
+and spins up on the first Slack event. Requires `TICKETING_MODE=slack`
+(see `docs/SLACK_SETUP.md`) — the JIRA polling loop (`agent start`) is a
+long-running process and isn't a fit for Cloud Run's request model.
+
+## Why `--no-cpu-throttling`
+
+Slack requires an HTTP ack within ~3 seconds, but a ticket (AI planning, git
+operations, quality gates, PR creation) takes minutes. The handler acks
+immediately and finishes the work in a background goroutine. By default
+Cloud Run throttles CPU to near-zero once a response is sent, which would
+stall that goroutine. `--no-cpu-throttling` keeps CPU allocated for the life
+of the container instance, not just the request, so background work
+actually runs to completion.
+
+This is an MVP tradeoff: under very sparse traffic, Cloud Run can still
+scale an idle instance down between the ack and the background work
+finishing. If that becomes a problem in practice, the fix is to hand off
+processing to Cloud Tasks (webhook enqueues a task, a second endpoint does
+the work with its own request lifetime) instead of a bare goroutine — not
+implemented here, note it as a follow-up if reliability issues show up.
+
+## 1. Build and push the image
+
+```bash
+PROJECT_ID=your-gcp-project
+REGION=us-central1
+IMAGE=us-central1-docker.pkg.dev/$PROJECT_ID/ai-intern/agent:latest
+
+gcloud auth configure-docker $REGION-docker.pkg.dev
+docker build -t $IMAGE .
+docker push $IMAGE
+```
+
+(Requires an Artifact Registry repo — `gcloud artifacts repositories create ai-intern --repository-format=docker --location=$REGION` if you don't have one yet.)
+
+## 2. Store secrets
+
+```bash
+echo -n "xoxb-..."      | gcloud secrets create slack-bot-token --data-file=-
+echo -n "..."           | gcloud secrets create slack-signing-secret --data-file=-
+echo -n "ghp_..."       | gcloud secrets create github-token --data-file=-
+echo -n "sk-ant-..."    | gcloud secrets create anthropic-api-key --data-file=-
+```
+
+## 3. Deploy
+
+```bash
+gcloud run deploy ai-intern-agent \
+  --image=$IMAGE \
+  --region=$REGION \
+  --platform=managed \
+  --no-cpu-throttling \
+  --timeout=3600 \
+  --min-instances=0 \
+  --max-instances=5 \
+  --concurrency=5 \
+  --memory=1Gi \
+  --set-env-vars="TICKETING_MODE=slack,GITHUB_OWNER=your-org,GITHUB_REPO=your-repo,AI_PROVIDER=anthropic,BASE_BRANCH=main,WORKING_DIR=/tmp/workspace" \
+  --set-secrets="SLACK_BOT_TOKEN=slack-bot-token:latest,SLACK_SIGNING_SECRET=slack-signing-secret:latest,GITHUB_TOKEN=github-token:latest,ANTHROPIC_API_KEY=anthropic-api-key:latest" \
+  --allow-unauthenticated
+```
+
+Notes:
+
+- `--allow-unauthenticated` is required so Slack can reach `/slack/events`
+  directly; the handler authenticates requests itself via Slack's request
+  signature (`SLACK_SIGNING_SECRET`), so this doesn't leave the endpoint open.
+- `WORKING_DIR=/tmp/workspace`: Cloud Run's filesystem is writable only
+  under `/tmp` (in-memory, cleared per instance) unless you mount a volume;
+  `/tmp` is fine here since each request re-clones/syncs the repo anyway.
+- `--concurrency=5` bounds how many Slack events one instance handles at
+  once; each is a full clone+AI+PR pipeline, so keep this low relative to
+  `--memory`.
+
+## 4. Point Slack at it
+
+```bash
+gcloud run services describe ai-intern-agent --region=$REGION --format='value(status.url)'
+```
+
+Use that URL + `/slack/events` as the Event Subscriptions Request URL
+(step 3 in `docs/SLACK_SETUP.md`).
+
+## 5. Verify
+
+```bash
+curl https://<service-url>/healthz
+```

--- a/docs/SLACK_SETUP.md
+++ b/docs/SLACK_SETUP.md
@@ -1,0 +1,75 @@
+# Slack Setup
+
+Lets you assign tasks to the agent and get status updates from a Slack conversation
+instead of requiring a JIRA account. This is the `TICKETING_MODE=slack` path,
+served over HTTP via `agent serve` (see `docs/CLOUD_RUN_DEPLOY.md` for deploying it).
+
+## 1. Create the Slack app
+
+1. Go to https://api.slack.com/apps → **Create New App** → **From scratch**.
+2. Name it (e.g. "AI Intern") and pick your workspace.
+
+## 2. Add bot scopes
+
+Under **OAuth & Permissions → Scopes → Bot Token Scopes**, add:
+
+- `app_mentions:read` — see `@AI Intern <ask>` mentions in channels
+- `chat:write` — post status replies
+- `im:history` — read DMs sent directly to the bot (optional, for DM-based asks)
+- `im:read` — required alongside `im:history` for DM support
+
+Install the app to your workspace, then copy the **Bot User OAuth Token**
+(`xoxb-...`) — this is `SLACK_BOT_TOKEN`.
+
+## 3. Subscribe to events
+
+Under **Event Subscriptions**:
+
+1. Toggle **Enable Events** on.
+2. **Request URL**: `https://<your-deployed-url>/slack/events`
+   - Slack sends a `url_verification` challenge here as soon as you enter the
+     URL — the agent must already be reachable (deploy first, see
+     `docs/CLOUD_RUN_DEPLOY.md`) for this step to succeed.
+3. Under **Subscribe to bot events**, add:
+   - `app_mention` — for `@AI Intern` mentions in channels
+   - `message.im` — for direct messages (optional)
+
+## 4. Get the signing secret
+
+Under **Basic Information → App Credentials**, copy the **Signing Secret** —
+this is `SLACK_SIGNING_SECRET`. The agent uses it to verify that incoming
+webhook requests actually came from Slack (HMAC-SHA256 over the request body,
+per Slack's request-signing scheme).
+
+## 5. Configure the agent
+
+```bash
+TICKETING_MODE=slack
+SLACK_BOT_TOKEN=xoxb-...
+SLACK_SIGNING_SECRET=...
+PORT=8080
+```
+
+GitHub and AI provider configuration (`GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, etc.)
+are still required — only the ticketing source changes. `JIRA_*` and
+`AGENT_USERNAME`/`POLLING_INTERVAL` are not required in `slack` mode.
+
+## 6. Run it
+
+```bash
+go run ./cmd/agent serve
+```
+
+Then in Slack: `@AI Intern add input validation to the signup handler`.
+The bot replies in-thread with an ack, then again with the PR link (or an
+error) once done — this can take several minutes for a real ticket, since it
+runs the full AI planning + quality-gate + PR pipeline.
+
+## Notes / limits (MVP)
+
+- One "ticket" per Slack thread (keyed by channel + thread timestamp), so
+  replying in the same thread does **not** currently continue the same
+  ticket — each mention starts a new one.
+- No access control yet: any user who can message the bot can trigger a
+  ticket. Restrict who can DM/invite the bot at the Slack app or channel
+  level until this is addressed.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/go-github/v58 v58.0.0
 	github.com/jenish-jain/logger v0.3.0
 	github.com/joho/godotenv v1.5.1
+	github.com/slack-go/slack v0.17.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
@@ -43,6 +44,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.14.0 h1:vgvQWe3XCz3gIeFDm/HnTIbj6UGmg/+t63MyGU2n5js=
 github.com/go-playground/validator/v10 v10.14.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
+github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
+github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
@@ -78,6 +80,8 @@ github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
@@ -129,6 +133,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
+github.com/slack-go/slack v0.17.0 h1:Vqd4GGIcwwgEu80GBs3cXoPPho5bkDGSFnuZbSG0NhA=
+github.com/slack-go/slack v0.17.0/go.mod h1:X+UqOufi3LYQHDnMG1vxf0J8asC6+WllXrVrhl8/Prk=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,11 +13,22 @@ import (
 )
 
 type Config struct {
+	// TicketingMode selects the source of tickets/asks: "jira" (default, poll loop)
+	// or "slack" (HTTP webhook, request-driven — used for the Cloud Run deployment).
+	TicketingMode string
+
 	JiraURL         string
 	JiraEmail       string
 	JiraAPIToken    string
 	JiraProject     string
 	JiraTransitions map[string]string
+
+	SlackBotToken      string
+	SlackSigningSecret string
+
+	// Port is the HTTP listen port for `agent serve` (Slack webhook + healthz).
+	// Cloud Run injects this via the PORT env var.
+	Port string
 
 	GitHubToken string
 	GitHubOwner string
@@ -26,9 +37,9 @@ type Config struct {
 	AnthropicAPIKey string
 
 	// AI Provider configuration
-	AIProvider     string // "anthropic" or "ollama"
-	OllamaBaseURL  string // Ollama server URL (default: http://localhost:11434)
-	OllamaModel    string // Ollama model name (e.g., qwen2.5-coder:7b)
+	AIProvider    string // "anthropic" or "ollama"
+	OllamaBaseURL string // Ollama server URL (default: http://localhost:11434)
+	OllamaModel   string // Ollama model name (e.g., qwen2.5-coder:7b)
 
 	AgentUsername        string
 	PollingInterval      string
@@ -38,10 +49,10 @@ type Config struct {
 	BaseBranch   string
 	BranchPrefix string
 
-	ContextMaxFiles      int
-	ContextMaxBytes      int
-	ContextCacheEnabled  bool   // Enable context caching
-	ContextCacheTTL      string // Cache time-to-live (e.g., "1h", "30m")
+	ContextMaxFiles     int
+	ContextMaxBytes     int
+	ContextCacheEnabled bool   // Enable context caching
+	ContextCacheTTL     string // Cache time-to-live (e.g., "1h", "30m")
 
 	PlanMaxFiles     int
 	AllowedWriteDirs []string
@@ -50,11 +61,11 @@ type Config struct {
 	RunVetBeforePR   bool
 
 	// Self-healing configuration
-	SelfHealEnabled      bool // Enable self-healing for failed quality gates
-	SelfHealMaxAttempts  int  // Maximum healing attempts (default: 3)
-	SelfHealOnTests      bool // Retry on test failures
-	SelfHealOnVet        bool // Retry on vet failures
-	SelfHealOnBuild      bool // Retry on build failures
+	SelfHealEnabled     bool // Enable self-healing for failed quality gates
+	SelfHealMaxAttempts int  // Maximum healing attempts (default: 3)
+	SelfHealOnTests     bool // Retry on test failures
+	SelfHealOnVet       bool // Retry on vet failures
+	SelfHealOnBuild     bool // Retry on build failures
 
 	DryRun bool // If true, process tickets but don't create PRs (preview mode)
 
@@ -68,6 +79,8 @@ func LoadConfig() (*Config, error) {
 	viper.AutomaticEnv()
 
 	cfg := &Config{
+		TicketingMode: viper.GetString("TICKETING_MODE"),
+
 		JiraURL:      viper.GetString("JIRA_URL"),
 		JiraEmail:    viper.GetString("JIRA_EMAIL"),
 		JiraAPIToken: viper.GetString("JIRA_API_TOKEN"),
@@ -77,6 +90,10 @@ func LoadConfig() (*Config, error) {
 			"In Progress": viper.GetString("JIRA_TRANSITION_IN_PROGRESS"),
 			"Done":        viper.GetString("JIRA_TRANSITION_DONE"),
 		},
+
+		SlackBotToken:      viper.GetString("SLACK_BOT_TOKEN"),
+		SlackSigningSecret: viper.GetString("SLACK_SIGNING_SECRET"),
+		Port:               viper.GetString("PORT"),
 
 		GitHubToken: viper.GetString("GITHUB_TOKEN"),
 		GitHubOwner: viper.GetString("GITHUB_OWNER"),
@@ -119,6 +136,12 @@ func LoadConfig() (*Config, error) {
 	}
 
 	// Defaults
+	if cfg.TicketingMode == "" {
+		cfg.TicketingMode = "jira" // Default to JIRA polling for backwards compatibility
+	}
+	if cfg.Port == "" {
+		cfg.Port = "8080"
+	}
 	if cfg.AIProvider == "" {
 		cfg.AIProvider = "anthropic" // Default to Anthropic for backwards compatibility
 	}
@@ -168,18 +191,41 @@ func LoadConfig() (*Config, error) {
 }
 
 func (c *Config) Validate() error {
-	// Validate required JIRA configuration
-	if c.JiraURL == "" {
-		return errors.NewConfigMissingError("JIRA_URL")
-	}
-	if c.JiraEmail == "" {
-		return errors.NewConfigMissingError("JIRA_EMAIL")
-	}
-	if c.JiraAPIToken == "" {
-		return errors.NewConfigMissingError("JIRA_API_TOKEN")
-	}
-	if c.JiraProject == "" {
-		return errors.NewConfigMissingError("JIRA_PROJECT_KEY")
+	// Validate ticketing mode and its required configuration
+	switch c.TicketingMode {
+	case "jira", "":
+		if c.JiraURL == "" {
+			return errors.NewConfigMissingError("JIRA_URL")
+		}
+		if c.JiraEmail == "" {
+			return errors.NewConfigMissingError("JIRA_EMAIL")
+		}
+		if c.JiraAPIToken == "" {
+			return errors.NewConfigMissingError("JIRA_API_TOKEN")
+		}
+		if c.JiraProject == "" {
+			return errors.NewConfigMissingError("JIRA_PROJECT_KEY")
+		}
+		if c.AgentUsername == "" {
+			return errors.NewConfigMissingError("AGENT_USERNAME")
+		}
+		if c.PollingInterval == "" {
+			return errors.NewConfigMissingError("POLLING_INTERVAL")
+		}
+		if _, err := time.ParseDuration(c.PollingInterval); err != nil {
+			return errors.NewConfigInvalidError("POLLING_INTERVAL", c.PollingInterval,
+				fmt.Sprintf("invalid duration format: %v (use: 30s, 5m, 1h, etc.)", err))
+		}
+	case "slack":
+		if c.SlackBotToken == "" {
+			return errors.NewConfigMissingError("SLACK_BOT_TOKEN")
+		}
+		if c.SlackSigningSecret == "" {
+			return errors.NewConfigMissingError("SLACK_SIGNING_SECRET")
+		}
+	default:
+		return errors.NewConfigInvalidError("TICKETING_MODE", c.TicketingMode,
+			"supported values: jira, slack")
 	}
 
 	// Validate required GitHub configuration
@@ -209,20 +255,6 @@ func (c *Config) Validate() error {
 	default:
 		return errors.NewConfigInvalidError("AI_PROVIDER", c.AIProvider,
 			"supported values: anthropic, ollama")
-	}
-
-	// Validate agent configuration
-	if c.AgentUsername == "" {
-		return errors.NewConfigMissingError("AGENT_USERNAME")
-	}
-
-	// Validate and parse polling interval
-	if c.PollingInterval == "" {
-		return errors.NewConfigMissingError("POLLING_INTERVAL")
-	}
-	if _, err := time.ParseDuration(c.PollingInterval); err != nil {
-		return errors.NewConfigInvalidError("POLLING_INTERVAL", c.PollingInterval,
-			fmt.Sprintf("invalid duration format: %v (use: 30s, 5m, 1h, etc.)", err))
 	}
 
 	// Validate concurrent tickets

--- a/internal/journal/journal.go
+++ b/internal/journal/journal.go
@@ -85,6 +85,21 @@ func (j *Journal) Reconcile(ctx context.Context, checkMerged func(ctx context.Co
 	return updated, nil
 }
 
+// Find returns the most recent entry for a ticket key, if one exists.
+// Used by request-driven callers (e.g. the Slack handler) that need the
+// PR URL for a ticket after ProcessTicket returns, since the ticketing.Client
+// UpdateTicketStatus callback only carries the status string, not the PR URL.
+func (j *Journal) Find(ticketKey string) (Entry, bool) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	for i := len(j.Entries) - 1; i >= 0; i-- {
+		if j.Entries[i].TicketKey == ticketKey {
+			return j.Entries[i], true
+		}
+	}
+	return Entry{}, false
+}
+
 // saveLocked performs an atomic write of the journal file (temp file +
 // rename, mirroring State.saveUnlocked). Must be called with j.mu held.
 func (j *Journal) saveLocked() error {

--- a/internal/orchestrator/coordinator.go
+++ b/internal/orchestrator/coordinator.go
@@ -209,6 +209,26 @@ func checkContext(ctx context.Context, ticketKey, checkpoint string) error {
 	}
 }
 
+// PrepareRepository clones/syncs the target repository. Exported for
+// request-driven callers (e.g. the Slack webhook handler) that process a
+// single ticket outside of Run()'s polling loop and need to ensure the repo
+// is ready before ProcessTicket runs.
+func (c *Coordinator) PrepareRepository(ctx context.Context) error {
+	return c.prepareRepository(ctx)
+}
+
+// ProcessTicket runs the full ticket pipeline (branch, plan, apply, quality
+// gates, push, PR, status update) for a single ticket. Exported so request-
+// driven trigger sources (Slack webhook, Cloud Run handler) can invoke it
+// directly for one ticket without going through Run()'s JIRA polling loop.
+func (c *Coordinator) ProcessTicket(ctx context.Context, key, summary, description string) error {
+	if err := c.processTicket(ctx, key, summary, description); err != nil {
+		return err
+	}
+	c.State.MarkProcessed(key)
+	return nil
+}
+
 func (c *Coordinator) prepareRepository(ctx context.Context) error {
 	repoPath := c.RepoPaths.Root()
 	if _, err := os.Stat(c.RepoPaths.GitDir()); os.IsNotExist(err) {

--- a/internal/ticketing/slack/client.go
+++ b/internal/ticketing/slack/client.go
@@ -1,0 +1,90 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"intern/internal/ticketing"
+
+	slackapi "github.com/slack-go/slack"
+)
+
+// Client implements ticketing.Client backed by Slack. Tickets here are
+// ad-hoc "asks" created from incoming Slack messages rather than pulled
+// from a backlog, so GetTickets is a no-op — each Slack event is processed
+// directly via Coordinator.ProcessTicket by Handler (see handler.go)
+// instead of going through Run()'s polling loop.
+type Client struct {
+	api *slackapi.Client
+
+	mu      sync.Mutex
+	threads map[string]ThreadRef // ticket key -> originating Slack thread
+}
+
+// New creates a Slack-backed ticketing client using a bot token
+// (xoxb-...) with chat:write and app_mentions:read/im:history scopes.
+func New(botToken string) *Client {
+	return &Client{
+		api:     slackapi.New(botToken),
+		threads: make(map[string]ThreadRef),
+	}
+}
+
+func (c *Client) HealthCheck(ctx context.Context) error {
+	if _, err := c.api.AuthTestContext(ctx); err != nil {
+		return fmt.Errorf("slack auth test failed: %w", err)
+	}
+	return nil
+}
+
+// GetTickets always returns an empty list: Slack pushes work via webhook
+// events rather than exposing a pollable backlog.
+func (c *Client) GetTickets(ctx context.Context, assignee, project string) ([]ticketing.Ticket, error) {
+	return nil, nil
+}
+
+// UpdateTicketStatus posts a short status line into the Slack thread that
+// originated the ticket, if one is registered. It's a no-op otherwise
+// (e.g. called for a ticket that wasn't created via Slack).
+func (c *Client) UpdateTicketStatus(ctx context.Context, ticketKey, status string, transitions map[string]string) error {
+	ref, ok := c.ThreadFor(ticketKey)
+	if !ok {
+		return nil
+	}
+	_, _, err := c.api.PostMessageContext(ctx, ref.Channel,
+		slackapi.MsgOptionText(fmt.Sprintf("Status: *%s*", status), false),
+		slackapi.MsgOptionTS(ref.ThreadTS),
+	)
+	return err
+}
+
+// RegisterThread associates a ticket key with the Slack thread that
+// created it, so later status/result replies land in the right place.
+func (c *Client) RegisterThread(ticketKey, channel, threadTS string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.threads[ticketKey] = ThreadRef{Channel: channel, ThreadTS: threadTS}
+}
+
+func (c *Client) ThreadFor(ticketKey string) (ThreadRef, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ref, ok := c.threads[ticketKey]
+	return ref, ok
+}
+
+// PostReply sends a plain message into the thread for a ticket. Used by
+// Handler for the immediate ack and final result (PR URL / error), which
+// carry information UpdateTicketStatus's signature has no room for.
+func (c *Client) PostReply(ctx context.Context, ticketKey, text string) error {
+	ref, ok := c.ThreadFor(ticketKey)
+	if !ok {
+		return fmt.Errorf("no registered thread for ticket %s", ticketKey)
+	}
+	_, _, err := c.api.PostMessageContext(ctx, ref.Channel,
+		slackapi.MsgOptionText(text, false),
+		slackapi.MsgOptionTS(ref.ThreadTS),
+	)
+	return err
+}

--- a/internal/ticketing/slack/factory.go
+++ b/internal/ticketing/slack/factory.go
@@ -1,0 +1,13 @@
+package slack
+
+import "fmt"
+
+// NewSlackClient mirrors the jira-raw factory pattern (see
+// internal/ticketing/jira-raw/factory.go) so wiring stays consistent across
+// ticketing backends.
+func NewSlackClient(botToken string) (*Client, error) {
+	if botToken == "" {
+		return nil, fmt.Errorf("slack bot token is required")
+	}
+	return New(botToken), nil
+}

--- a/internal/ticketing/slack/handler.go
+++ b/internal/ticketing/slack/handler.go
@@ -1,0 +1,211 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"intern/internal/orchestrator"
+
+	logger "github.com/jenish-jain/logger"
+	slackapi "github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+)
+
+// eventDedupeWindow bounds how long a Slack event_id is remembered for
+// retry de-duplication; Slack stops retrying well before this expires.
+const eventDedupeWindow = 10 * time.Minute
+
+var mentionPrefix = regexp.MustCompile(`^\s*<@[A-Z0-9]+>\s*`)
+
+// Handler serves Slack's Events API webhook (POST /slack/events) and turns
+// incoming messages into single-ticket runs on the coordinator. This is the
+// request-driven entrypoint the Cloud Run deployment triggers on.
+type Handler struct {
+	client        *Client
+	signingSecret string
+	coordinator   *orchestrator.Coordinator
+
+	mu   sync.Mutex
+	seen map[string]time.Time // event_id -> received time, dedupes Slack retries
+}
+
+func NewHandler(client *Client, signingSecret string, coordinator *orchestrator.Coordinator) *Handler {
+	return &Handler{
+		client:        client,
+		signingSecret: signingSecret,
+		coordinator:   coordinator,
+		seen:          make(map[string]time.Time),
+	}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	sv, err := slackapi.NewSecretsVerifier(r.Header, h.signingSecret)
+	if err != nil {
+		logger.Warn("Slack signature verifier setup failed", "error", err)
+		http.Error(w, "invalid request", http.StatusUnauthorized)
+		return
+	}
+	if _, err := sv.Write(body); err != nil {
+		http.Error(w, "invalid request", http.StatusUnauthorized)
+		return
+	}
+	if err := sv.Ensure(); err != nil {
+		logger.Warn("Slack signature verification failed", "error", err)
+		http.Error(w, "invalid signature", http.StatusUnauthorized)
+		return
+	}
+
+	event, err := slackevents.ParseEvent(json.RawMessage(body), slackevents.OptionNoVerifyToken())
+	if err != nil {
+		logger.Warn("Failed to parse Slack event", "error", err)
+		http.Error(w, "bad event payload", http.StatusBadRequest)
+		return
+	}
+
+	switch event.Type {
+	case slackevents.URLVerification:
+		var ve slackevents.EventsAPIURLVerificationEvent
+		if err := json.Unmarshal(body, &ve); err != nil {
+			http.Error(w, "bad challenge payload", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(ve.Challenge))
+
+	case slackevents.CallbackEvent:
+		// Slack requires an ack within ~3s and retries on timeout/non-2xx.
+		// Respond immediately and do the (multi-minute) ticket processing
+		// in the background — this is why the Cloud Run deployment must
+		// run with CPU always allocated (see docs/CLOUD_RUN_DEPLOY.md).
+		w.WriteHeader(http.StatusOK)
+
+		eventID := ""
+		if cb, ok := event.Data.(*slackevents.EventsAPICallbackEvent); ok {
+			eventID = cb.EventID
+		}
+		if !h.markSeen(eventID) {
+			return // Slack redelivered an event we've already started processing
+		}
+		go h.handleCallback(context.Background(), event)
+
+	default:
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+// markSeen de-dupes on Slack's event_id, since Slack retries webhook
+// delivery on slow acks or non-2xx responses.
+func (h *Handler) markSeen(id string) bool {
+	if id == "" {
+		return true // no ID to dedupe on (shouldn't happen); process it
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	now := time.Now()
+	for k, t := range h.seen {
+		if now.Sub(t) > eventDedupeWindow {
+			delete(h.seen, k)
+		}
+	}
+	if _, ok := h.seen[id]; ok {
+		return false
+	}
+	h.seen[id] = now
+	return true
+}
+
+func (h *Handler) handleCallback(ctx context.Context, event slackevents.EventsAPIEvent) {
+	var channel, threadTS, text string
+
+	switch ev := event.InnerEvent.Data.(type) {
+	case *slackevents.AppMentionEvent:
+		channel = ev.Channel
+		threadTS = firstNonEmpty(ev.ThreadTimeStamp, ev.TimeStamp)
+		text = ev.Text
+	case *slackevents.MessageEvent:
+		// Only handle plain direct messages to the bot; ignore channel
+		// chatter, the bot's own messages, and edit/delete subtypes.
+		if ev.ChannelType != "im" || ev.BotID != "" || ev.SubType != "" {
+			return
+		}
+		channel = ev.Channel
+		threadTS = firstNonEmpty(ev.ThreadTimeStamp, ev.TimeStamp)
+		text = ev.Text
+	default:
+		return
+	}
+
+	ask := strings.TrimSpace(mentionPrefix.ReplaceAllString(text, ""))
+	key := ticketKeyFor(channel, threadTS)
+	h.client.RegisterThread(key, channel, threadTS)
+
+	if ask == "" {
+		_ = h.client.PostReply(ctx, key, "I need a description of what to do — try `@intern <describe the task>`.")
+		return
+	}
+
+	summary := summarize(ask)
+	_ = h.client.PostReply(ctx, key, fmt.Sprintf("On it — working on: %s", summary))
+
+	if err := h.coordinator.PrepareRepository(ctx); err != nil {
+		logger.Error("Slack: repository preparation failed", "error", err)
+		_ = h.client.PostReply(ctx, key, fmt.Sprintf("Couldn't prepare the repository: %v", err))
+		return
+	}
+
+	if err := h.coordinator.ProcessTicket(ctx, key, summary, ask); err != nil {
+		logger.Error("Slack: ticket processing failed", "key", key, "error", err)
+		_ = h.client.PostReply(ctx, key, fmt.Sprintf("Failed: %v", err))
+		return
+	}
+
+	if entry, ok := h.coordinator.Journal.Find(key); ok && entry.PRURL != "" {
+		_ = h.client.PostReply(ctx, key, fmt.Sprintf("Done — opened %s", entry.PRURL))
+	} else {
+		_ = h.client.PostReply(ctx, key, "Done.")
+	}
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// ticketKeyFor derives a stable, branch-name-safe ticket key from the
+// originating Slack conversation so repeated events in the same thread map
+// to the same ticket (and so orchestrator.State can dedupe reprocessing).
+func ticketKeyFor(channel, threadTS string) string {
+	sanitized := strings.NewReplacer(".", "", ":", "").Replace(threadTS)
+	return fmt.Sprintf("SLACK-%s-%s", channel, sanitized)
+}
+
+func summarize(ask string) string {
+	line := strings.SplitN(ask, "\n", 2)[0]
+	const maxLen = 80
+	if len(line) <= maxLen {
+		return line
+	}
+	return line[:maxLen-1] + "…"
+}

--- a/internal/ticketing/slack/types.go
+++ b/internal/ticketing/slack/types.go
@@ -1,0 +1,8 @@
+package slack
+
+// ThreadRef identifies the Slack conversation a ticket originated from, so
+// status updates and results can be replied back into the right thread.
+type ThreadRef struct {
+	Channel  string
+	ThreadTS string
+}


### PR DESCRIPTION
## Summary
- New `TICKETING_MODE=slack` path: assign/converse with the agent via Slack mentions/DMs instead of requiring a JIRA account. Implements a Slack Events API webhook (`internal/ticketing/slack/`), including request signature verification and event de-duplication.
- New `agent serve` command (`cmd/agent/commands/serve.go`) exposing `/slack/events` and `/healthz` over HTTP — a request-driven entrypoint (ack immediately, process in background) suited to Cloud Run's scale-to-zero model.
- Dockerfile + `docs/CLOUD_RUN_DEPLOY.md` for deploying `agent serve` to Cloud Run (`--no-cpu-throttling` required so background ticket processing can finish after the HTTP response).
- `docs/SLACK_SETUP.md` walks through creating the Slack app, scopes, and signing secret.
- `TICKETING_MODE` defaults to `jira`, so existing JIRA-polling deployments (`agent start`) are unaffected.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — passes, except `TestUpdateIndex_FileAdded` in `internal/indexer`, which fails identically on unmodified `master` (pre-existing flake, unrelated to this change)
- [x] `gofmt -l` clean on touched files
- [ ] Manual: send a real Slack event through `agent serve` end-to-end (requires a Slack app + bot token, not yet configured)
- [ ] Manual: deploy to Cloud Run and verify `/healthz` + a live Slack event

🤖 Generated with [Claude Code](https://claude.com/claude-code)