### PR TITLE
Add Cloud Run deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy
+
+on:
+  push:
+    branches: [master]
+
+env:
+  PROJECT: realm-asgard
+  REGION: asia-south1
+  SERVICE: ai-intern-agent
+  IMAGE: asia-south1-docker.pkg.dev/realm-asgard/intern/agent
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: realm-asgard   # grants access to environment-scoped secrets GCP_WIF_PROVIDER + GCP_CI_SA
+    permissions:
+      contents: read
+      id-token: write   # required for Workload Identity Federation
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@v2
+        with:
+          # Set GCP_WIF_PROVIDER under repo/org Settings → Secrets and variables → Actions → Secrets
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          # Set GCP_CI_SA under repo/org Settings → Secrets and variables → Actions → Secrets
+          service_account: ${{ secrets.GCP_CI_SA }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy ${{ env.SERVICE }} \
+            --image ${{ env.IMAGE }}:${{ github.sha }} \
+            --region ${{ env.REGION }} --project ${{ env.PROJECT }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml`: on push to master, authenticates to GCP via Workload Identity Federation, builds/pushes the Docker image to the `intern` Artifact Registry repo, then runs `gcloud run deploy ai-intern-agent`.
- Mirrors the existing pattern in the `kosh` repo's `deploy.yml`.
- Without this, merges to master had no effect on the deployed Cloud Run service (it would keep running the placeholder image).

## Requires (before this workflow will succeed)
- `GCP_WIF_PROVIDER` and `GCP_CI_SA` secrets set under a `realm-asgard` GitHub Environment (values come from the `intern_wif_provider` / `intern_ci_service_account` Terraform outputs in the `infrastructure` repo).

## Test plan
- [ ] Merge to master and confirm the `Deploy` workflow run succeeds
- [ ] Confirm `gcloud run services describe ai-intern-agent` reflects the new image SHA after the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)