### PR TITLE
Fix indexer incrementally indexing its own state file

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -117,6 +117,16 @@ func (idx *Indexer) shouldSkipDir(relPath string) bool {
 func (idx *Indexer) shouldSkipFile(relPath string) bool {
 	lower := strings.ToLower(relPath)
 
+	// Skip files inside excluded directories — needed because the incremental
+	// updater (UpdateIndex) checks files individually via git diff rather than
+	// walking the tree with shouldSkipDir, so e.g. .ai-intern/file_index.json
+	// would otherwise get indexed as a regular changed file.
+	for _, excluded := range excludedDirs {
+		if lower == excluded || strings.HasPrefix(lower, excluded+"/") {
+			return true
+		}
+	}
+
 	// Skip binary and media files
 	for _, ext := range binaryExts {
 		if strings.HasSuffix(lower, ext) {


### PR DESCRIPTION
## Summary
- \`make test\` was failing on \`TestUpdateIndex_FileAdded\`: incremental \`UpdateIndex()\` was indexing \`.ai-intern/file_index.json\` (its own state file) as a regular changed file whenever it got committed alongside real changes
- \`shouldSkipFile\` only filtered binary extensions and file size; directory exclusion (\`excludedDirs\`, e.g. \`.ai-intern\`) was only applied in \`BuildIndex\`'s tree walk via \`shouldSkipDir\`, not in the incremental path
- Now \`shouldSkipFile\` also checks \`excludedDirs\`

## Test plan
- [x] \`make test\` passes locally, including \`TestUpdateIndex_FileAdded\`
- [x] \`make vet\` clean