### PR TITLE
Skip vet/test in CI on push to master

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,10 +22,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Only run on pull_request: master already passed these checks before
+      # merge, so re-running on push here would just cost time for no signal.
       - name: Run vet
+        if: github.event_name == 'pull_request'
         run: make vet
 
       - name: Run tests
+        if: github.event_name == 'pull_request'
         run: make test
 
       - name: Update coverage report


### PR DESCRIPTION
## Summary
- `ci` job's `Run vet`/`Run tests` steps now only run on `pull_request` events (initial open + new commits pushed to the PR)
- They're skipped on `push` to master, since those checks already passed during PR review — re-running them post-merge just costs CI time
- `release`/`deploy` (which `needs: ci`) are unaffected: a job with skipped steps still reports `success`, so the `needs:` chain continues to work on push to master

## Test plan
- [ ] Open this PR and confirm vet/test steps run in the `ci` job
- [ ] Merge and confirm the `ci` job's vet/test steps are skipped while `release`/`deploy` still run

🤖 Generated with [Claude Code](https://claude.com/claude-code)