### PR TITLE
Allow ALLOWED_WRITE_DIRS="*" to opt out of the directory allowlist

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -173,6 +173,7 @@ func LoadConfig() (*Config, error) {
 		cfg.MetricsPort = 9090 // Default Prometheus port
 	}
 	// MetricsEnabled defaults to false (opt-in)
+	// "*" disables the allowlist check entirely — see validatePlannedChanges.
 	allowed := viper.GetString("ALLOWED_WRITE_DIRS")
 	if strings.TrimSpace(allowed) == "" {
 		cfg.AllowedWriteDirs = []string{"internal", "cmd", "pkg", "docs", "config", "."}

--- a/internal/orchestrator/validation.go
+++ b/internal/orchestrator/validation.go
@@ -39,12 +39,15 @@ func validatePlannedChanges(root string, changes []agent.CodeChange, allowedDirs
 			logger.Warn("Rejecting attempt to modify Go dependency file", "path", clean)
 			continue
 		}
-		// Enforce allowlist
-		first := firstSegment(clean)
-		// Allow root-level files if "." is in allowedDirs
-		if !inList(first, allowedDirs) && !(first == clean && inList(".", allowedDirs)) {
-			logger.Debug("Skipping path not in allowed directories", "path", clean, "first_segment", first, "allowed_dirs", allowedDirs)
-			continue
+		// Enforce allowlist, unless "*" opts out of it entirely (needed since
+		// target repos vary in directory layout and a fixed list doesn't generalize).
+		if !inList("*", allowedDirs) {
+			first := firstSegment(clean)
+			// Allow root-level files if "." is in allowedDirs
+			if !inList(first, allowedDirs) && !(first == clean && inList(".", allowedDirs)) {
+				logger.Debug("Skipping path not in allowed directories", "path", clean, "first_segment", first, "allowed_dirs", allowedDirs)
+				continue
+			}
 		}
 		// Ensure a payload is present: create needs content, edit needs hunks,
 		// delete needs neither.


### PR DESCRIPTION
## Summary
- `validatePlannedChanges` skips the directory-allowlist check entirely when `allowedDirs` contains `"*"`.
- All other guards (no absolute paths, no path traversal, no go.mod/go.sum edits, file count limit) still apply.

## Why
The default allowlist (`internal, cmd, pkg, docs, config, .`) was designed for the intern repo's own layout. Now that the agent is being pointed at other target repos (e.g. `infrastructure`, via `GITHUB_OWNER`/`GITHUB_REPO`), a fixed list rejects legitimate paths in those repos (e.g. `modules/mongodb-sharded-cluster/...`). This is a temporary allow-all; a per-repo blacklist can be added later if it proves too permissive.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/orchestrator/... ./internal/config/...`
- [ ] After merge + deploy, confirm the Slack-triggered MongoDB module PR against `infrastructure` no longer skips paths under `modules/`