### PR TITLE
Verify push landed on remote before creating PR

### DIFF
--- a/internal/orchestrator/coordinator.go
+++ b/internal/orchestrator/coordinator.go
@@ -571,8 +571,12 @@ func (c *Coordinator) processTicket(ctx context.Context, key, summary, descripti
 		return nil // Exit early without creating PR
 	}
 
-	if err := c.Repository.Push(ctx, branchName); err != nil {
-		return fmt.Errorf("push: %w", err)
+	pushErr, pushAttempts := Retry(ctx, BackoffConfig{Initial: time.Second, Max: 10 * time.Second, Multiplier: 2, Jitter: 0.2, MaxRetries: 3}, func() error {
+		return MakeTransient(c.Repository.Push(ctx, branchName))
+	})
+	c.Metrics.AddRetries(pushAttempts)
+	if pushErr != nil {
+		return fmt.Errorf("push: %w", pushErr)
 	}
 	base := c.Cfg.BaseBranch
 	if base == "" {

--- a/internal/repository/github/client.go
+++ b/internal/repository/github/client.go
@@ -219,6 +219,15 @@ func (c *githubClient) Push(ctx context.Context, branchName string) error {
 	if err != nil && err != git.NoErrAlreadyUpToDate {
 		return fmt.Errorf("failed to push to remote: %w", err)
 	}
+
+	// go-git can report success (including NoErrAlreadyUpToDate) against a
+	// working directory reused across runs on a warm instance without the
+	// branch actually landing on the remote — confirm it did, since a
+	// silent no-op here otherwise surfaces later as a confusing "invalid
+	// head" error from PR creation instead of a clear push failure.
+	if _, _, err := c.ghClient.Git.GetRef(ctx, c.owner, c.repo, fmt.Sprintf("refs/heads/%s", branchName)); err != nil {
+		return fmt.Errorf("push reported success but branch %s not found on remote: %w", branchName, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- `Push()` now confirms via the GitHub API that the branch ref actually exists on the remote after pushing, instead of trusting go-git's local success/`NoErrAlreadyUpToDate` result blindly.
- `Push()` is now wrapped in the same retry-with-backoff (3 attempts) already used for PR creation.

## Why
Saw this in production:
```
Failed: create PR: transient
failed to create pull request: POST .../pulls: 422 Validation Failed [{Resource:PullRequest Field:head Code:invalid Message:}]
```
`git ls-remote --heads` on the target repo showed the branch never actually existed remotely, even though `Push()` returned no error and processing moved on to (repeatedly failing) PR creation. `WORKING_DIR` is a persistent `/tmp` directory reused across ticket runs on a warm Cloud Run instance (see `serve` mode + `prepareRepository`, which only re-clones if `.git` is missing) — go-git's push status determination against that reused local state doesn't appear to reliably reflect the true remote, particularly after the earlier-fixed issue where deploys could kill a run mid-push. The fix makes this failure mode loud and retryable at the actual point of failure (the push) instead of surfacing as a confusing PR-creation error three retries later.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/orchestrator/... ./internal/repository/...`
- [ ] Re-trigger a Slack task and confirm the branch is visible via `git ls-remote` before PR creation is attempted