### PR TITLE
Report AI cost/token usage in Slack success and failure replies

### DIFF
--- a/internal/orchestrator/coordinator.go
+++ b/internal/orchestrator/coordinator.go
@@ -30,19 +30,41 @@ type Coordinator struct {
 	Metrics    *Metrics
 	RepoPaths  *repository.RepositoryPath // Centralized path management
 	Journal    *journal.Journal           // Cross-ticket continuity log
+
+	ticketMetricsMu sync.Mutex
+	ticketMetrics   map[string]*TicketMetrics // last-known metrics per ticket key, for request-driven callers (see LastTicketMetrics)
 }
 
 func NewCoordinator(ticketing *ticketing.Service, repository *repository.RepositoryService, agent agent.Agent, cfg *config.Config, state *State, repoPaths *repository.RepositoryPath) *Coordinator {
 	return &Coordinator{
-		Ticketing:  ticketing,
-		Repository: repository,
-		Agent:      agent,
-		Cfg:        cfg,
-		State:      state,
-		Metrics:    NewMetrics(),
-		RepoPaths:  repoPaths,
-		Journal:    journal.Load(repoPaths.Root()),
+		Ticketing:     ticketing,
+		Repository:    repository,
+		Agent:         agent,
+		Cfg:           cfg,
+		State:         state,
+		Metrics:       NewMetrics(),
+		RepoPaths:     repoPaths,
+		Journal:       journal.Load(repoPaths.Root()),
+		ticketMetrics: make(map[string]*TicketMetrics),
 	}
+}
+
+// LastTicketMetrics returns the most recently recorded metrics for a ticket
+// key, if any. Populated as soon as a ticket starts processing and updated
+// in place as AI usage data becomes available, so it's readable after
+// ProcessTicket returns regardless of whether the ticket succeeded or
+// failed partway through.
+func (c *Coordinator) LastTicketMetrics(key string) (*TicketMetrics, bool) {
+	c.ticketMetricsMu.Lock()
+	defer c.ticketMetricsMu.Unlock()
+	tm, ok := c.ticketMetrics[key]
+	return tm, ok
+}
+
+func (c *Coordinator) storeTicketMetrics(key string, tm *TicketMetrics) {
+	c.ticketMetricsMu.Lock()
+	defer c.ticketMetricsMu.Unlock()
+	c.ticketMetrics[key] = tm
 }
 
 func (c *Coordinator) Run(ctx context.Context) {
@@ -258,6 +280,13 @@ func (c *Coordinator) prepareRepository(ctx context.Context) error {
 func (c *Coordinator) processTicket(ctx context.Context, key, summary, description string) error {
 	startTime := time.Now()
 
+	// Recorded early and updated in place (rather than replaced) as the
+	// pipeline progresses, so cost data is available via LastTicketMetrics
+	// even if a later step fails - Status only flips to "success" if the
+	// full pipeline completes.
+	ticketMetrics := &TicketMetrics{TicketKey: key, Status: "failed", Timestamp: startTime}
+	c.storeTicketMetrics(key, ticketMetrics)
+
 	branchName := buildBranchName(c.Cfg.BranchPrefix, key)
 	logger.Info("Creating branch", "branch", branchName)
 	if err := c.Repository.CreateBranch(ctx, branchName); err != nil {
@@ -385,7 +414,7 @@ func (c *Coordinator) processTicket(ctx context.Context, key, summary, descripti
 	}
 
 	// Create per-ticket metrics for tracking
-	ticketMetrics := NewTicketMetricsFromUsage(key, usageMetrics)
+	ticketMetrics.ApplyUsage(usageMetrics)
 	ticketMetrics.SetRetryCount(attempts)
 
 	// Estimate savings if smart context was used
@@ -626,6 +655,7 @@ func (c *Coordinator) processTicket(ctx context.Context, key, summary, descripti
 
 	ticketMetrics.SetExecutionTime(executionTime)
 	ticketMetrics.SetFilesChanged(filesChanged)
+	ticketMetrics.Status = "success"
 
 	c.Metrics.IncTicketsProcessed()
 	c.Metrics.AddExecutionTime(executionTime)

--- a/internal/orchestrator/ticket_metrics.go
+++ b/internal/orchestrator/ticket_metrics.go
@@ -105,6 +105,24 @@ func NewTicketMetricsFromUsage(ticketKey string, usage *agent.UsageMetrics) *Tic
 	}
 }
 
+// ApplyUsage fills in the AI-usage-derived fields (tokens, cost, context
+// stats) on an existing TicketMetrics once planning succeeds, leaving
+// TicketKey/Timestamp/Status untouched - Status is set separately once the
+// full pipeline completes, since planning succeeding doesn't guarantee the
+// rest of the ticket does.
+func (tm *TicketMetrics) ApplyUsage(usage *agent.UsageMetrics) {
+	if usage == nil {
+		return
+	}
+	tm.InputTokens = usage.InputTokens
+	tm.OutputTokens = usage.OutputTokens
+	tm.Cost = usage.EstimatedCost
+	tm.ContextStrategy = usage.ContextStats.Strategy
+	tm.FilesInContext = usage.ContextStats.FilesIncluded
+	tm.ContextSizeBytes = usage.ContextStats.ContextBytes
+	tm.KeywordsExtracted = usage.ContextStats.Keywords
+}
+
 // MarkFailed marks the ticket as failed with an error message.
 func (tm *TicketMetrics) MarkFailed(err error) {
 	tm.Status = "failed"

--- a/internal/ticketing/slack/handler.go
+++ b/internal/ticketing/slack/handler.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"intern/internal/ai"
 	"intern/internal/orchestrator"
 
 	logger "github.com/jenish-jain/logger"
@@ -173,15 +174,32 @@ func (h *Handler) handleCallback(ctx context.Context, event slackevents.EventsAP
 
 	if err := h.coordinator.ProcessTicket(ctx, key, summary, ask); err != nil {
 		logger.Error("Slack: ticket processing failed", "key", key, "error", err)
-		_ = h.client.PostReply(ctx, key, fmt.Sprintf("Failed: %v", err))
+		_ = h.client.PostReply(ctx, key, fmt.Sprintf("Failed: %v%s", err, h.costSuffix(key)))
 		return
 	}
 
 	if entry, ok := h.coordinator.Journal.Find(key); ok && entry.PRURL != "" {
-		_ = h.client.PostReply(ctx, key, fmt.Sprintf("Done — opened %s", entry.PRURL))
+		_ = h.client.PostReply(ctx, key, fmt.Sprintf("Done — opened %s%s", entry.PRURL, h.costSuffix(key)))
 	} else {
-		_ = h.client.PostReply(ctx, key, "Done.")
+		_ = h.client.PostReply(ctx, key, fmt.Sprintf("Done.%s", h.costSuffix(key)))
 	}
+}
+
+// costSuffix renders a "\n\n_cost: ..._" line from the ticket's recorded
+// metrics (actual cost incurred, plus what full context would have cost if
+// smart context selection was used), or "" if no metrics were recorded yet
+// (e.g. processing failed before any AI call was made).
+func (h *Handler) costSuffix(key string) string {
+	tm, ok := h.coordinator.LastTicketMetrics(key)
+	if !ok || (tm.InputTokens == 0 && tm.OutputTokens == 0) {
+		return ""
+	}
+	actual := fmt.Sprintf("actual %s (%s in / %s out tokens)",
+		ai.FormatCost(tm.Cost), ai.FormatTokens(tm.InputTokens), ai.FormatTokens(tm.OutputTokens))
+	if tm.EstimatedFullContextCost > 0 {
+		return fmt.Sprintf("\n\n_cost: %s, estimated %s without smart context_", actual, ai.FormatCost(tm.EstimatedFullContextCost))
+	}
+	return fmt.Sprintf("\n\n_cost: %s_", actual)
 }
 
 func firstNonEmpty(vals ...string) string {


### PR DESCRIPTION
## Summary
- Adds `Coordinator.LastTicketMetrics(key)`: a per-ticket-key store of `*TicketMetrics`, recorded as soon as a ticket starts processing and updated in place as usage data comes in — so it's readable after `ProcessTicket` returns regardless of success or failure (previously `TicketMetrics` was only ever logged server-side and discarded).
- `TicketMetrics.Status` now only flips to `"success"` once the pipeline truly completes (PR created), rather than as soon as AI planning succeeds.
- The Slack handler now appends a cost line to both the "Done" and "Failed" replies: actual cost + input/output token counts, plus the estimated full-context cost when smart context selection was used (no line at all if processing failed before any AI call, e.g. repo prep failure — there's no cost to report).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/orchestrator/... ./internal/ai/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)