### PR TITLE
Fix non-Go context truncation causing hallucinated edits

### DIFF
--- a/internal/ai/agent/templates.go
+++ b/internal/ai/agent/templates.go
@@ -21,9 +21,9 @@ type PlanPromptOptions struct {
 func BuildPlanChangesPrompt(ticketKey, ticketSummary, ticketDescription, repoContext string, opts PlanPromptOptions) string {
 	rules := []string{
 		"Output ONLY a compact JSON array. No markdown, no backticks, no commentary.",
-		`For NEW files: {"path":"relative/path.go","operation":"create","content":"<full file content>"}`,
-		`For EXISTING files: {"path":"relative/path.go","operation":"edit","edits":[{"old":"<exact lines copied verbatim from the file, including indentation>","new":"<replacement lines>"}]}`,
-		`To delete: {"path":"relative/path.go","operation":"delete"}`,
+		`For NEW files: {"path":"relative/path.ext","operation":"create","content":"<full file content>"}`,
+		`For EXISTING files: {"path":"relative/path.ext","operation":"edit","edits":[{"old":"<exact lines copied verbatim from the file, including indentation>","new":"<replacement lines>"}]}`,
+		`To delete: {"path":"relative/path.ext","operation":"delete"}`,
 		"NEVER use operation create on a file that already exists in the repository context - use edit.",
 		"In each edit, the old block MUST be copied character-for-character from the provided file content, and MUST be unique within the file. Include 2-3 unchanged surrounding lines for uniqueness.",
 		"Keep edits minimal: change only what the ticket requires. Do not reformat or rewrite untouched code.",
@@ -31,10 +31,11 @@ func BuildPlanChangesPrompt(ticketKey, ticketSummary, ticketDescription, repoCon
 		"Fulfil every acceptance criterion in the ticket; add nothing beyond it.",
 		"Use POSIX-style relative paths under the repo root.",
 		`Files marked "(full content)" are shown verbatim and may be edited. Files marked "(signatures only)" show declarations without bodies and CANNOT be safely edited.`,
-		`Only use operation=edit on files shown with full content. If you need to modify a file shown as signatures-only, respond with ONLY {"need_files":["relative/path.go", ...]} (no array, no other keys) and nothing else - you will be given the full content and asked again.`,
+		`Only use operation=edit on files shown with full content. If you need to modify a file shown as signatures-only, respond with ONLY {"need_files":["relative/path.ext", ...]} (no array, no other keys) and nothing else - you will be given the full content and asked again.`,
+		`If a name the ticket asked for (a resource, variable, identifier, etc.) already exists for something unrelated, don't fail the ticket - pick a clear, non-colliding alternative yourself and continue. Record what you changed and why in that change's "note" field, e.g. {"path":"...","operation":"edit","edits":[...],"note":"renamed X to Y: X already exists for an unrelated resource"}. Use "note" sparingly, only for judgment calls a human should be able to review or override - not for routine changes.`,
 	}
 	return fmt.Sprintf(
-		"You are a senior Go engineer\nTicket: %s - %s\nDescription:\n%s\n\nRepository context (truncated):\n%s\n\nRules:\n- %s\n\nJSON:",
+		"You are a senior software engineer making a focused, minimal change to an existing repository (which may contain code, infrastructure-as-code, or configuration).\nTicket: %s - %s\nDescription:\n%s\n\nRepository context (truncated):\n%s\n\nRules:\n- %s\n\nJSON:",
 		strings.TrimSpace(ticketKey),
 		strings.TrimSpace(ticketSummary),
 		strings.TrimSpace(ticketDescription),

--- a/internal/ai/agent/types.go
+++ b/internal/ai/agent/types.go
@@ -23,6 +23,10 @@ type CodeChange struct {
 	Operation CodeChangeOperation `json:"operation"`
 	Content   string              `json:"content,omitempty"` // create only
 	Edits     []EditHunk          `json:"edits,omitempty"`   // edit only
+	// Note is an optional, AI-authored explanation of a judgment call made
+	// on this change (e.g. renaming a resource to avoid a naming collision).
+	// Surfaced in the PR description so a human can confirm or override it.
+	Note string `json:"note,omitempty"`
 }
 
 // ParseNeedFiles checks whether raw is a {"need_files":["path", ...]}

--- a/internal/indexer/parser.go
+++ b/internal/indexer/parser.go
@@ -427,10 +427,30 @@ func receiverTypeName(expr ast.Expr) string {
 	}
 }
 
+// nonGoFullContentMaxBytes is the size under which non-Go files are shown
+// in full rather than truncated to a prefix, matching this function's
+// documented (previously unimplemented) intent. Unlike Go source - where a
+// package/import/signature header is genuinely representative of the whole
+// file - declarative config files (Terraform, YAML, JSON) have no "head"
+// that's more relevant than the rest: a variable/resource block near the
+// end is exactly as load-bearing as one at the top. A blind prefix cut
+// silently hides real content from the model instead of summarizing it,
+// which is worse than useless when the model is later asked to edit that
+// file - it has no way to know that what it can't see even exists.
+const nonGoFullContentMaxBytes = 16 * 1024
+
 // extractNonGoContext extracts context from non-Go files (config, docs, etc.).
-// For small files (<10KB), it returns the full content.
-// For larger files, it returns the first 100 lines to avoid excessive context.
+// For small files (<16KB), it returns the full content. For larger files,
+// it returns the first 100 lines to avoid excessive context.
 func extractNonGoContext(filePath string) (string, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+	if len(data) <= nonGoFullContentMaxBytes {
+		return fmt.Sprintf("# File: %s\n\n%s", filePath, string(data)), nil
+	}
+
 	file, err := os.Open(filePath)
 	if err != nil {
 		return "", err
@@ -440,26 +460,21 @@ func extractNonGoContext(filePath string) (string, error) {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("# File: %s\n\n", filePath))
 
-	// For non-code files, include first 50 lines or 2KB, whichever is smaller
 	scanner := bufio.NewScanner(file)
 	lineCount := 0
-	maxLines := 50
-	maxBytes := 2048
-	bytesRead := 0
+	maxLines := 100
 
-	for scanner.Scan() && lineCount < maxLines && bytesRead < maxBytes {
-		line := scanner.Text()
-		sb.WriteString(line)
+	for scanner.Scan() && lineCount < maxLines {
+		sb.WriteString(scanner.Text())
 		sb.WriteString("\n")
 		lineCount++
-		bytesRead += len(line) + 1
 	}
 
 	if err := scanner.Err(); err != nil && err != io.EOF {
 		return sb.String(), err
 	}
 
-	if lineCount >= maxLines || bytesRead >= maxBytes {
+	if lineCount >= maxLines {
 		sb.WriteString("\n... (truncated)\n")
 	}
 

--- a/internal/indexer/parser_test.go
+++ b/internal/indexer/parser_test.go
@@ -1,6 +1,7 @@
 package indexer
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -199,13 +200,36 @@ Line 5
 	assert.Contains(t, result, "Line 3")
 }
 
-func TestExtractMinimalContext_LargeNonGoFile(t *testing.T) {
-	// Create a large file with 100 lines
+func TestExtractMinimalContext_SmallNonGoFileNotTruncated(t *testing.T) {
+	// A file with many short lines but well under the full-content size
+	// threshold should be returned in full, not truncated to a prefix -
+	// declarative config files (e.g. Terraform) have no "head" that's more
+	// relevant than the rest, so blindly cutting them hides real content
+	// from the model instead of summarizing it.
 	var sb strings.Builder
 	for i := 1; i <= 100; i++ {
 		sb.WriteString("Line ")
 		sb.WriteString(string(rune('0' + i)))
 		sb.WriteString("\n")
+	}
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "small.txt")
+	err := os.WriteFile(testFile, []byte(sb.String()), 0644)
+	require.NoError(t, err)
+
+	result, err := ExtractMinimalContext(testFile)
+	require.NoError(t, err)
+
+	assert.NotContains(t, result, "... (truncated)")
+	assert.Contains(t, result, "Line ") // last line (100th)
+}
+
+func TestExtractMinimalContext_LargeNonGoFile(t *testing.T) {
+	// Create a file that exceeds the full-content size threshold.
+	var sb strings.Builder
+	for i := 0; i < 2000; i++ {
+		sb.WriteString(fmt.Sprintf("Line %d of filler content to exceed the threshold\n", i))
 	}
 
 	tmpDir := t.TempDir()
@@ -219,9 +243,9 @@ func TestExtractMinimalContext_LargeNonGoFile(t *testing.T) {
 	// Should be truncated
 	assert.Contains(t, result, "... (truncated)")
 
-	// Should not include all 100 lines
+	// Should not include all 2000 lines
 	lines := strings.Split(result, "\n")
-	assert.Less(t, len(lines), 100, "Should truncate large files")
+	assert.Less(t, len(lines), 2000, "Should truncate large files")
 }
 
 func TestExtractMinimalContext_InvalidGoFile(t *testing.T) {

--- a/internal/orchestrator/coordinator.go
+++ b/internal/orchestrator/coordinator.go
@@ -366,37 +366,46 @@ func (c *Coordinator) processTicket(ctx context.Context, key, summary, descripti
 	// Retrieval pass: the model asked to see the full content of files shown
 	// signatures-only (responded with {"need_files":[...]} instead of
 	// changes). Rebuild context with those files promoted to the
-	// full-content tier and plan again - this second call is cheap since the
-	// first response is just a short need_files list.
-	if len(needFiles) > 0 && usedSmartContext {
-		logger.Info("AI requested full content for additional files", "ticket", key, "files", needFiles)
+	// full-content tier and plan again - this is cheap since a need_files
+	// response is just a short list. Bounded and iterative: each round's
+	// need_files accumulate on top of prior rounds', so a model that still
+	// needs another file after seeing the first batch can ask again instead
+	// of being forced to guess at content it was never shown.
+	const maxRetrievalRounds = 3
+	fullContentFiles := needFiles
+	for round := 0; len(fullContentFiles) > 0 && usedSmartContext && round < maxRetrievalRounds; round++ {
+		logger.Info("AI requested full content for additional files", "ticket", key, "files", fullContentFiles, "round", round+1)
 
-		ctxStr2, ctxErr2 := ai.BuildSmartRepoContext(repoRoot, description, c.Cfg.ContextMaxFiles, needFiles)
+		ctxStr2, ctxErr2 := ai.BuildSmartRepoContext(repoRoot, description, c.Cfg.ContextMaxFiles, fullContentFiles)
 		if ctxErr2 != nil {
-			logger.Warn("Failed to rebuild context for requested files, proceeding without retrieval pass",
+			logger.Warn("Failed to rebuild context for requested files, proceeding without further retrieval",
 				"ticket", key, "error", ctxErr2)
-		} else {
-			ctxStr = priorWork + ctxStr2
-
-			var changes2 []agent.CodeChange
-			var usageMetrics2 *agent.UsageMetrics
-			planErr2, attempts2 := Retry(ctx, planBackoff, func() error {
-				ch, _, metrics, e := c.Agent.PlanChanges(ctx, key, summary, description, ctxStr)
-				if e != nil {
-					return MakeTransient(e)
-				}
-				changes2 = ch
-				usageMetrics2 = metrics
-				return nil
-			})
-			c.Metrics.AddRetries(attempts2)
-			if planErr2 != nil {
-				c.Metrics.IncAIPlanFailures()
-				return fmt.Errorf("AI planning failed (retrieval pass): %w", planErr2)
-			}
-			changes = changes2
-			usageMetrics = sumUsageMetrics(usageMetrics, usageMetrics2)
+			break
 		}
+		ctxStr = priorWork + ctxStr2
+
+		var changes2 []agent.CodeChange
+		var needFiles2 []string
+		var usageMetrics2 *agent.UsageMetrics
+		planErr2, attempts2 := Retry(ctx, planBackoff, func() error {
+			ch, nf, metrics, e := c.Agent.PlanChanges(ctx, key, summary, description, ctxStr)
+			if e != nil {
+				return MakeTransient(e)
+			}
+			changes2 = ch
+			needFiles2 = nf
+			usageMetrics2 = metrics
+			return nil
+		})
+		c.Metrics.AddRetries(attempts2)
+		if planErr2 != nil {
+			c.Metrics.IncAIPlanFailures()
+			return fmt.Errorf("AI planning failed (retrieval pass): %w", planErr2)
+		}
+		changes = changes2
+		usageMetrics = sumUsageMetrics(usageMetrics, usageMetrics2)
+
+		fullContentFiles = mergeUnique(fullContentFiles, needFiles2)
 	}
 
 	// Checkpoint 2: Check for cancellation after AI planning (expensive operation)
@@ -611,6 +620,15 @@ func (c *Coordinator) processTicket(ctx context.Context, key, summary, descripti
 	if base == "" {
 		base = "main"
 	}
+	// Surface any judgment calls the AI made while planning (e.g. renaming a
+	// resource to avoid a naming collision) so a human can confirm or
+	// override them, rather than the ticket silently failing on ambiguity.
+	for _, ch := range valid {
+		if ch.Note != "" {
+			notes = append(notes, fmt.Sprintf("%s: %s", ch.Path, ch.Note))
+		}
+	}
+
 	title := buildPRTitle(key, summary)
 	body := buildPRBody(key, summary, description, valid, notes)
 	var prURL string
@@ -767,4 +785,24 @@ func sumUsageMetrics(a, b *agent.UsageMetrics) *agent.UsageMetrics {
 			Keywords:      b.ContextStats.Keywords,
 		},
 	}
+}
+
+// mergeUnique returns the union of a and b, preserving a's order and
+// appending any elements of b not already present in a.
+func mergeUnique(a, b []string) []string {
+	seen := make(map[string]bool, len(a))
+	out := make([]string, 0, len(a)+len(b))
+	for _, v := range a {
+		if !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	for _, v := range b {
+		if !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	return out
 }

--- a/internal/orchestrator/validation.go
+++ b/internal/orchestrator/validation.go
@@ -65,7 +65,7 @@ func validatePlannedChanges(root string, changes []agent.CodeChange, allowedDirs
 			}
 		}
 		logger.Debug("Accepting change", "path", clean, "operation", ch.Operation)
-		out = append(out, agent.CodeChange{Path: clean, Operation: ch.Operation, Content: ch.Content, Edits: ch.Edits})
+		out = append(out, agent.CodeChange{Path: clean, Operation: ch.Operation, Content: ch.Content, Edits: ch.Edits, Note: ch.Note})
 	}
 	logger.Debug("Validation complete", "accepted_changes", len(out), "rejected_changes", len(changes)-len(out))
 	if len(out) == 0 {


### PR DESCRIPTION
## Summary
- Root-cause fix for the recurring `hunk 1: old block not found` failures on Terraform edits: `extractNonGoContext` always truncated non-Go files to 50 lines/2KB regardless of size (contradicting its own docstring), so the AI never saw the real content of variables past that point and hallucinated edit hunks against it. Now returns full content for files under 16KB, truncating only genuinely large files.
- Makes the `need_files` retrieval pass in `ProcessTicket` iterative (bounded at 3 rounds) instead of single-shot, so the model isn't forced to guess if it still needs more file content after the first retrieval round.
- Adds an optional `Note` field to `CodeChange` so the AI can record judgment calls it makes autonomously (e.g. renaming a resource to avoid a naming collision) instead of failing the ticket outright. Notes are surfaced in the PR description for human review, and the planning prompt now explicitly instructs the model to resolve small ambiguities this way.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Re-run the "lesgo-mongo" MongoDB sharded cluster Slack ticket end-to-end against the `infrastructure` repo to confirm the `variables.tf` edit-hunk failure no longer recurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)